### PR TITLE
feat: add crawler module for async network crawling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,22 @@
+name: checks
+
+on: [push, pull_request]
+
+jobs:
+  cargofmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: fmt
+        run: cargo fmt -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+
+      - name: clippy
+        run: cargo clippy -- -D warnings --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 /target
+*.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,44 +309,16 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.31",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core 0.4.5",
+ "axum-core",
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "itoa",
  "matchit",
@@ -356,25 +328,8 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
  "tower-layer",
  "tower-service",
 ]
@@ -388,13 +343,13 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -416,21 +371,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -1060,25 +1003,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.5.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
@@ -1088,7 +1012,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http",
  "indexmap 2.5.0",
  "slab",
  "tokio",
@@ -1150,17 +1074,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -1172,23 +1085,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -1199,16 +1101,10 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
@@ -1230,30 +1126,6 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
@@ -1261,9 +1133,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.6",
- "http 1.1.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1275,23 +1147,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.31",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.4.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1307,9 +1167,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
- "hyper 1.4.1",
+ "http",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1442,8 +1302,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addresses"
-version = "0.15.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.15.2#9fae376500c3b7bde4ac0d0f03f15d47a4d6f12c"
+version = "0.16.0"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.16.0#178c0605f53b9e204bdfce8538fd9c7e67f3c443"
 dependencies = [
  "borsh",
  "js-sys",
@@ -1457,9 +1317,10 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-core"
-version = "0.15.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.15.2#9fae376500c3b7bde4ac0d0f03f15d47a4d6f12c"
+version = "0.16.0"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.16.0#178c0605f53b9e204bdfce8538fd9c7e67f3c443"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "borsh",
  "cfg-if",
@@ -1492,8 +1353,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-core"
-version = "0.15.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.15.2#9fae376500c3b7bde4ac0d0f03f15d47a4d6f12c"
+version = "0.16.0"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.16.0#178c0605f53b9e204bdfce8538fd9c7e67f3c443"
 dependencies = [
  "cfg-if",
  "ctrlc",
@@ -1511,8 +1372,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-hashes"
-version = "0.15.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.15.2#9fae376500c3b7bde4ac0d0f03f15d47a4d6f12c"
+version = "0.16.0"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.16.0#178c0605f53b9e204bdfce8538fd9c7e67f3c443"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -1530,8 +1391,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-math"
-version = "0.15.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.15.2#9fae376500c3b7bde4ac0d0f03f15d47a4d6f12c"
+version = "0.16.0"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.16.0#178c0605f53b9e204bdfce8538fd9c7e67f3c443"
 dependencies = [
  "borsh",
  "faster-hex",
@@ -1550,16 +1411,16 @@ dependencies = [
 
 [[package]]
 name = "kaspa-merkle"
-version = "0.15.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.15.2#9fae376500c3b7bde4ac0d0f03f15d47a4d6f12c"
+version = "0.16.0"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.16.0#178c0605f53b9e204bdfce8538fd9c7e67f3c443"
 dependencies = [
  "kaspa-hashes",
 ]
 
 [[package]]
 name = "kaspa-mining-errors"
-version = "0.15.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.15.2#9fae376500c3b7bde4ac0d0f03f15d47a4d6f12c"
+version = "0.16.0"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.16.0#178c0605f53b9e204bdfce8538fd9c7e67f3c443"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror",
@@ -1567,8 +1428,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-muhash"
-version = "0.15.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.15.2#9fae376500c3b7bde4ac0d0f03f15d47a4d6f12c"
+version = "0.16.0"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.16.0#178c0605f53b9e204bdfce8538fd9c7e67f3c443"
 dependencies = [
  "kaspa-hashes",
  "kaspa-math",
@@ -1578,13 +1439,13 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-lib"
-version = "0.15.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.15.2#9fae376500c3b7bde4ac0d0f03f15d47a4d6f12c"
+version = "0.16.0"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.16.0#178c0605f53b9e204bdfce8538fd9c7e67f3c443"
 dependencies = [
  "borsh",
  "ctrlc",
  "futures",
- "h2 0.4.6",
+ "h2",
  "itertools 0.13.0",
  "kaspa-consensus-core",
  "kaspa-core",
@@ -1595,22 +1456,22 @@ dependencies = [
  "kaspa-utils-tower",
  "log",
  "parking_lot",
- "prost 0.12.6",
+ "prost",
  "rand",
  "seqlock",
  "serde",
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic 0.10.2",
+ "tonic",
  "tonic-build",
  "uuid 1.11.0",
 ]
 
 [[package]]
 name = "kaspa-txscript-errors"
-version = "0.15.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.15.2#9fae376500c3b7bde4ac0d0f03f15d47a4d6f12c"
+version = "0.16.0"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.16.0#178c0605f53b9e204bdfce8538fd9c7e67f3c443"
 dependencies = [
  "secp256k1",
  "thiserror",
@@ -1618,8 +1479,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils"
-version = "0.15.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.15.2#9fae376500c3b7bde4ac0d0f03f15d47a4d6f12c"
+version = "0.16.0"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.16.0#178c0605f53b9e204bdfce8538fd9c7e67f3c443"
 dependencies = [
  "arc-swap",
  "async-channel 2.3.1",
@@ -1648,16 +1509,18 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils-tower"
-version = "0.15.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.15.2#9fae376500c3b7bde4ac0d0f03f15d47a4d6f12c"
+version = "0.16.0"
+source = "git+https://github.com/kaspanet/rusty-kaspa.git?tag=v0.16.0#178c0605f53b9e204bdfce8538fd9c7e67f3c443"
 dependencies = [
+ "bytes",
  "cfg-if",
  "futures",
- "hyper 0.14.31",
+ "http-body",
+ "http-body-util",
  "log",
  "pin-project-lite",
  "tokio",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-http",
 ]
 
@@ -1683,7 +1546,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tonic 0.12.3",
+ "tonic",
  "uuid 1.11.0",
 ]
 
@@ -1720,7 +1583,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "libc",
 ]
 
@@ -1898,7 +1761,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -1911,7 +1774,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -2191,30 +2054,20 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
 dependencies = [
  "bytes",
  "prost-derive",
 ]
 
 [[package]]
-name = "prost"
+name = "prost-build"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
- "bytes",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
-dependencies = [
- "bytes",
  "heck",
  "itertools 0.11.0",
  "log",
@@ -2222,7 +2075,7 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.12.6",
+ "prost",
  "prost-types",
  "regex",
  "syn 2.0.87",
@@ -2231,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
  "itertools 0.11.0",
@@ -2244,11 +2097,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
 dependencies = [
- "prost 0.12.6",
+ "prost",
 ]
 
 [[package]]
@@ -2316,7 +2169,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2404,23 +2257,11 @@ version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
 ]
 
 [[package]]
@@ -2433,18 +2274,9 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -2453,7 +2285,7 @@ version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "rustls-pki-types",
 ]
 
@@ -2462,16 +2294,6 @@ name = "rustls-pki-types"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -2501,16 +2323,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "secp256k1"
@@ -2734,12 +2546,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
@@ -2876,16 +2682,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,21 +2694,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.13",
+ "rustls",
  "rustls-pki-types",
  "tokio",
 ]
@@ -2960,28 +2746,30 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.10.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
+ "axum",
+ "base64",
  "bytes",
  "flate2",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.31",
- "hyper-timeout 0.4.1",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.12.6",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "prost",
+ "rustls-pemfile",
+ "socket2",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -2991,47 +2779,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
+name = "tonic-build"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.7.9",
- "base64 0.22.1",
- "bytes",
- "flate2",
- "h2 0.4.6",
- "http 1.1.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.4.1",
- "hyper-timeout 0.5.2",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost 0.13.4",
- "rustls-pemfile 2.1.3",
- "socket2",
- "tokio",
- "tokio-rustls 0.26.0",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
+ "prost-types",
  "quote",
  "syn 2.0.87",
 ]
@@ -3065,24 +2821,22 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "bytes",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-range-header",
+ "http",
+ "http-body",
+ "http-body-util",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -3106,7 +2860,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3347,9 +3100,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,9 +917,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -932,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -942,15 +942,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -959,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -978,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -989,21 +989,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1676,6 +1676,7 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "clap",
+ "futures",
  "itertools 0.13.0",
  "kaspa-p2p-lib",
  "kaspa-utils",
@@ -2592,9 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ overflow-checks = true
 panic = "abort"
 
 [dependencies]
-kaspa-p2p-lib = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v0.15.2" }
-kaspa-utils = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v0.15.2" }
+kaspa-p2p-lib = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v0.16.0" }
+kaspa-utils = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v0.16.0" }
 
 clap = { version = "4.5.16", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["fs", "sync", "rt-multi-thread", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ kaspa-p2p-lib = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v0
 kaspa-utils = { git = "https://github.com/kaspanet/rusty-kaspa.git", tag = "v0.15.2" }
 
 clap = { version = "4.5.16", features = ["derive"] }
-tokio = { version = "1.40.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.40.0", features = ["fs", "sync", "rt-multi-thread", "time"] }
 tonic = { version = "0.12.3", features = ["tls", "gzip"] }
 itertools = "0.13.0"
 uuid = { version = "1.11.0", features = ["v4"] }
 chrono = { version = "0.4.38", features = ["serde"] }
-serde_json = "1.0.128"
+serde_json = "1.0.138"
 serde = { version = "1.0.210", features = ["derive"] }
+futures = { version = "0.3.31", features = ["std"] }

--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ Help
 Usage: kp2p [OPTIONS] <REQUEST>
 
 Arguments:
-  <REQUEST>  Request type [possible values: version, addresses]
+  <REQUEST>  Request type [possible values:
+    * version: Retrieves the version of the Kaspa node
+    * addresses: Retrieves a list of addresses from the Kaspa node
+    * crawl: Initiates a network crawl starting from the specified node]
 
 Options:
   -s, --url <URL>          The ip:port of a kaspad instance [default: localhost:16111]
   -n, --network <NETWORK>  The network type and suffix, e.g. 'testnet-11' [default: mainnet]
+  -o, --output <OUTPUT>    Output JSON file for crawl mode [default: nodes.json]
 ```

--- a/src/crawler.rs
+++ b/src/crawler.rs
@@ -1,0 +1,226 @@
+use crate::initializer::{Initializer, ROUTER};
+use crate::Cli;
+use futures::future::join_all;
+use kaspa_p2p_lib::pb::kaspad_message::Payload;
+use kaspa_p2p_lib::pb::RequestAddressesMessage;
+use kaspa_p2p_lib::{make_message, Hub};
+use kaspa_utils::hex::ToHex;
+use kaspa_utils::networking::IpAddress;
+use serde::Serialize;
+use std::collections::{HashSet, VecDeque};
+use std::net::IpAddr;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::fs;
+use tokio::sync::{mpsc, Mutex};
+use tokio::task;
+use tokio::time::{sleep, timeout};
+
+#[derive(Eq, PartialEq, Hash, Serialize, Clone)]
+struct NetAddress {
+    ip: IpAddr,
+    port: u16,
+}
+
+#[derive(Serialize, Clone)]
+struct NodeData {
+    ip: String,
+    metadata: NodeMetadata,
+}
+
+#[derive(Serialize, Clone)]
+struct NodeMetadata {
+    protocol_version: u32,
+    network: String,
+    services: u64,
+    timestamp: String,
+    id: String,
+    user_agent: String,
+    disable_relay_tx: bool,
+}
+
+/// crawl from the node provided in cli_args.url
+pub async fn crawl_network(cli_args: Arc<Cli>) {
+    let discovered_peers = Arc::new(Mutex::new(HashSet::new()));
+    let results = Arc::new(Mutex::new(Vec::new()));
+    let queue = Arc::new(Mutex::new(VecDeque::new()));
+
+    println!("Starting network crawl from {}", cli_args.url);
+    queue.lock().await.push_back(cli_args.url.clone());
+
+    // continue until there are no more nodes in the queue
+    while !queue.lock().await.is_empty() {
+        // drain current queue into a batch for concurrent processing
+        let batch = {
+            let mut queue_lock = queue.lock().await;
+            // drain all nodes currently in queue
+            queue_lock.drain(..).collect::<Vec<String>>()
+        };
+
+        println!("Processing {} nodes in parallel...", batch.len());
+        // async task for each node in the batch
+        let tasks = batch
+            .into_iter()
+            .map(|url| {
+                let cli_args = cli_args.clone();
+                let discovered_peers = Arc::clone(&discovered_peers);
+                let results = Arc::clone(&results);
+                let queue = Arc::clone(&queue);
+
+                task::spawn(async move {
+                    println!("Querying node: {}", url);
+                    // each task queries a single node and processes the response
+                    match query_node(cli_args.clone(), &url).await {
+                        Ok((url, peers, Some(metadata))) => {
+                            println!("Node {} successfully handshaken and returned {} peer(s)", url, peers.len());
+                            {
+                                let mut results_lock = results.lock().await;
+                                results_lock.push(NodeData { ip: url.clone(), metadata });
+                            }
+                            // process discovered peers from current node
+                            let mut discovered_lock = discovered_peers.lock().await;
+                            let mut queue_lock = queue.lock().await;
+                            for peer in peers {
+                                // only add new peers to avoid duplicate processing
+                                if discovered_lock.contains(&peer) {
+                                    continue;
+                                }
+                                discovered_lock.insert(peer.clone());
+                                let peer_addr = format!("{}:{}", peer.ip, peer.port);
+                                queue_lock.push_back(peer_addr.clone());
+                                println!("Discovered new peer: {}", peer_addr);
+                            }
+                        }
+                        Ok((url, _, None)) => {
+                            println!("Skipping node {} because handshake failed", url);
+                        }
+                        Err(_) => {
+                            println!("Failed to query node: {}", url);
+                        }
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        // If no tasks were spawned, there are no new nodes to query
+        if tasks.is_empty() {
+            println!("No new nodes to query, exiting...");
+            break;
+        } else {
+            println!("Awaiting {} concurrent node queries...", tasks.len());
+        }
+
+        // Await all tasks concurrently using join_all
+        // This is the batch processing step: all node queries in the current batch run in parallel
+        join_all(tasks).await;
+        println!("Completed batch, checking queue for next nodes...");
+    }
+
+    println!("Finalizing results...");
+    // serialize collected results to JSON
+    let results_guard = results.lock().await;
+    let nodes = (*results_guard).clone();
+    drop(results_guard);
+
+    let json_data = serde_json::to_string_pretty(&nodes).expect("Failed to serialize results to JSON");
+
+    if let Err(e) = fs::write(Path::new(&cli_args.output), json_data).await {
+        eprintln!("Error writing JSON file: {}", e);
+    }
+}
+
+/// Query a single node at the given URL and return its discovered addresses and handshake metadata
+/// returns error if handshake fails
+async fn query_node(cli_args: Arc<Cli>, url: &str) -> Result<(String, Vec<NetAddress>, Option<NodeMetadata>), ()> {
+    println!("Connecting to node: {}", url);
+
+    // channel to receive messages from peer
+    let (sender, mut receiver) = mpsc::channel(10);
+    let initializer = Arc::new(Initializer::new(cli_args.clone(), sender));
+    let adaptor = kaspa_p2p_lib::Adaptor::client_only(Hub::new(), initializer, Default::default());
+
+    // attempt connecting up to 3 times
+    for attempt in 1..=3 {
+        if adaptor.connect_peer_with_retries(url.to_string(), 3, Duration::from_secs(1)).await.is_err() {
+            println!("Connection attempt {}/3 failed: {}", attempt, url);
+            if attempt == 3 {
+                println!("Skipping node {} after 3 failed attempts", url);
+                adaptor.terminate_all_peers().await;
+                return Err(());
+            }
+            sleep(Duration::from_secs(1)).await;
+        } else {
+            break;
+        }
+    }
+
+    // Retrieve shared router from global state
+    let router = {
+        let router_guard = ROUTER.read().unwrap();
+        router_guard.clone()
+    };
+    let router = if let Some(router) = router {
+        router
+    } else {
+        println!("Router is not initialized, skipping node: {}", url);
+        adaptor.terminate_all_peers().await;
+        return Err(());
+    };
+
+    // Send a request to get peers list
+    let _ = router
+        .enqueue(make_message!(
+            Payload::RequestAddresses,
+            RequestAddressesMessage { include_all_subnetworks: false, subnetwork_id: None }
+        ))
+        .await;
+
+    let mut addresses = Vec::new();
+    let mut metadata: Option<NodeMetadata> = None;
+
+    // Listen for responses with a timeout to avoid hanging indefinitely
+    loop {
+        match timeout(Duration::from_secs(3), receiver.recv()).await {
+            Ok(Some(msg)) => match msg.payload {
+                Some(Payload::Addresses(addresses_msg)) => {
+                    for address in addresses_msg.address_list {
+                        if let Ok(result) = address.try_into() {
+                            let (ip, port): (IpAddress, u16) = result;
+                            addresses.push(NetAddress { ip: ip.to_canonical(), port });
+                        }
+                    }
+                    println!("Received {} addresses from {}", addresses.len(), url);
+                }
+                Some(Payload::Version(version_msg)) => {
+                    metadata = Some(NodeMetadata {
+                        protocol_version: version_msg.protocol_version,
+                        network: version_msg.network,
+                        services: version_msg.services,
+                        timestamp: chrono::Utc::now().to_rfc3339(),
+                        id: version_msg.id.to_hex(),
+                        user_agent: version_msg.user_agent,
+                        disable_relay_tx: version_msg.disable_relay_tx,
+                    });
+                    println!("Received metadata from {}", url);
+                }
+                _ => {}
+            },
+            Ok(None) => break,
+            Err(_) => {
+                println!("Timeout reached while waiting for messages from {}", url);
+                break;
+            }
+        }
+    }
+
+    println!("Disconnected from {}", url);
+    adaptor.terminate_all_peers().await;
+
+    // only return nodes that completed handshake successfully
+    if metadata.is_some() {
+        Ok((url.to_string(), addresses, metadata))
+    } else {
+        Err(())
+    }
+}

--- a/src/initializer.rs
+++ b/src/initializer.rs
@@ -35,7 +35,7 @@ impl ConnectionInitializer for Initializer {
         let sender = self.sender.clone();
         tokio::spawn(async move {
             while let Some(msg) = incoming_route.recv().await {
-                if !sender.send(msg).await.is_ok() {
+                if sender.send(msg).await.is_err() {
                     break;
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
+mod crawler;
 mod initializer;
 
+use crate::crawler::crawl_network;
 use crate::initializer::{Initializer, ROUTER};
 use chrono::{DateTime, Utc};
 use clap::{Parser, ValueEnum};
@@ -16,20 +18,27 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Receiver;
 
-#[derive(ValueEnum, Clone, Debug)]
+#[derive(ValueEnum, Clone, Debug, PartialEq)]
 enum RequestType {
     Version,
     Addresses,
+    Crawl,
 }
 
-#[derive(Parser)]
+#[derive(Parser, Clone, Debug)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
+    #[arg(value_enum, help = "Request type (version, addresses, crawl)")]
+    pub request: RequestType,
+
     #[clap(short = 's', long, default_value = "localhost:16111", help = "The ip:port of a kaspad instance")]
-    url: String,
+    pub url: String,
+
     #[clap(short, long, default_value = "mainnet", help = "The network type and suffix, e.g. 'testnet-11'")]
     pub network: String,
-    #[clap(value_enum, help = "Request type")]
-    pub request: RequestType,
+
+    #[clap(short = 'o', long, default_value = "nodes.json", help = "Output JSON file (for crawl mode)")]
+    pub output: String,
 }
 
 #[derive(Eq, PartialEq, Hash, Serialize)]
@@ -55,6 +64,13 @@ struct NetAddress {
 async fn main() {
     let cli_args = Arc::new(Cli::parse());
 
+    if cli_args.request == RequestType::Crawl {
+        println!("Starting network crawl...");
+        crawl_network(cli_args.clone()).await;
+        println!("Crawl complete. Data saved to {}", cli_args.output);
+        return;
+    }
+
     let (sender, mut receiver) = mpsc::channel(10);
     let initializer = Arc::new(Initializer::new(cli_args.clone(), sender));
     let adaptor = kaspa_p2p_lib::Adaptor::client_only(Hub::new(), initializer, Default::default());
@@ -68,6 +84,7 @@ async fn main() {
     match cli_args.request {
         RequestType::Version => req_version(&mut receiver).await,
         RequestType::Addresses => req_addresses(&mut receiver, router).await,
+        RequestType::Crawl => {}
     }
     adaptor.terminate_all_peers().await;
 }


### PR DESCRIPTION
- crawler spawns asynchronous tasks for each node in current batch. Each task performs a handshake to retrieve node metadata (protocol version, network, etc.) and discovers additional peer addresses
- add a very simple ci workflow + apply clippy suggestions
- bump kaspa p2p lib and kaspa utils to v0.16.0